### PR TITLE
ステップ11: Railsのタイムゾーンを設定しよう

### DIFF
--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -5,6 +5,9 @@
 <div>
     <%= @task.description %>
 </div>
+<div>
+    <%= @task.created_at %>
+</div>
 
 <%= link_to '編集', edit_task_path(@task) %>
 <%= link_to "削除", @task, method: :delete, data: { confirm: "タスクを削除してもよろしいですか？" } %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,5 +21,7 @@ module MofMofTraining1
 
     # ロケールファイルを複数読み込み可能にする
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+
+    config.time_zone = 'Asia/Tokyo'
   end
 end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -18,9 +18,10 @@ RSpec.describe 'Tasks', type: :system do
     let!(:task){ FactoryBot.create(:task) }
 
     it '詳細が表示される' do
-      visit tasks_path(task)
+      visit task_path(task)
       expect(page).to have_content task.name
       expect(page).to have_content task.description
+      expect(page).to have_content task.created_at
     end
 
   end
@@ -41,6 +42,8 @@ RSpec.describe 'Tasks', type: :system do
       it '作成できる' do
         expect(page).to have_content name
         expect(page).to have_content description
+        expect(page).to have_content /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/
+        
       end
     end
 
@@ -74,6 +77,7 @@ RSpec.describe 'Tasks', type: :system do
       it '編集できる' do
         expect(page).to have_content name
         expect(page).to have_content description
+        expect(page).to have_content /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/
       end
     end
     


### PR DESCRIPTION
[**ステップ11**](https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9711-rails%E3%81%AE%E3%82%BF%E3%82%A4%E3%83%A0%E3%82%BE%E3%83%BC%E3%83%B3%E3%82%92%E8%A8%AD%E5%AE%9A%E3%81%97%E3%82%88%E3%81%86)
- やったこと
`config.time_zone = 'Asia/Tokyo'`でタイムゾーンを東京に指定
タスク詳細画面にタスク作成日時を追加
タスク作成日時のテストを追加
タスク詳細のシステムテスト修正(パスが一覧ページになっていた)

- 確認したこと
`Time.zone`でJSTになっていることを確認
テスト実行

- 確認してほしいこと
正しくタイムゾーンが設定されているかどうか