### PR TITLE
ステップ12: タスク一覧を作成日時の順番で並び替えよう

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:edit, :show, :update, :destroy]
 
   def index
-    @tasks = Task.all
+    @tasks = Task.all.order(created_at: "DESC")
   end
   
   def show

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,11 +1,19 @@
 <h1>Tasks#index</h1>
+
 <%= link_to '新規作成', new_task_path %>
+
 <% @tasks.each do |task| %>
-<div>
-    <%= task.name %>
-</div>
-<div>
-    <%= task.description %>
-</div>
-<%= link_to '詳細を見る', task_path(task) %>
+
+    <div class="task">
+        <div class="task_column">
+            <%= task.name %>
+        </div>
+
+        <div class="task_column" id="task_created_at">
+            <%= task.created_at %>
+        </div>
+    </div>
+    
+    <%= link_to '詳細を見る', task_path(task) %>
+
 <% end %>

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -4,26 +4,29 @@ RSpec.describe 'Tasks', type: :system do
 
   describe '一覧' do
 
-    # 順番のテストのため、順序をバラバラに作成 letの名前を日付の降順で命名
-    let!(:task_order1){ FactoryBot.create(:task, created_at: Time.now + 1.days) }
-    let!(:task_order0){ FactoryBot.create(:task, created_at: Time.now + 1.years) }
-    let!(:task_order2){ FactoryBot.create(:task, created_at: Time.now + 1.hours) }
-    let!(:task_order3){ FactoryBot.create(:task) }
+    let!(:task){ FactoryBot.create(:task) }
+    let!(:task_add_1year){ FactoryBot.create(:task, created_at: Time.now + 1.years) }
+    let!(:task_add_1day){ FactoryBot.create(:task, created_at: Time.now + 1.days) }
+    let!(:task_add_1hour){ FactoryBot.create(:task, created_at: Time.now + 1.hours) }
 
     before do
       visit tasks_path
     end
     
     it '一覧で表示される' do
-      expect(page).to have_content task_order0.name
-      expect(page).to have_content task_order0.created_at
+      expect(page).to have_content task.name
+      expect(page).to have_content task.created_at
     end
 
     it '作成日の降順で並ぶ' do
-      page.all(".task").each_with_index do | task, idx | 
-        display_text = task.find_by_id('task_created_at').text
-        expect(display_text).to eq eval("task_order#{idx}").created_at.to_s
-      end
+
+      task_list = page.all('.task')
+      id_of_task_created = 'task_created_at'
+
+      expect(task_list[0].find_by_id(id_of_task_created).text).to eq task_add_1year.created_at.to_s # 現在日時 + 1年
+      expect(task_list[1].find_by_id(id_of_task_created).text).to eq task_add_1day.created_at.to_s # 現在日時 + 1日
+      expect(task_list[2].find_by_id(id_of_task_created).text).to eq task_add_1hour.created_at.to_s # 現在日時 + 1時間
+      expect(task_list[3].find_by_id(id_of_task_created).text).to eq task.created_at.to_s # 現在日時
     end
     
   end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -4,11 +4,26 @@ RSpec.describe 'Tasks', type: :system do
 
   describe '一覧' do
 
-    let!(:task){ FactoryBot.create(:task) }
+    # 順番のテストのため、順序をバラバラに作成 letの名前を日付の降順で命名
+    let!(:task_order1){ FactoryBot.create(:task, created_at: Time.now + 1.days) }
+    let!(:task_order0){ FactoryBot.create(:task, created_at: Time.now + 1.years) }
+    let!(:task_order2){ FactoryBot.create(:task, created_at: Time.now + 1.hours) }
+    let!(:task_order3){ FactoryBot.create(:task) }
 
-    it '一覧で表示される' do
+    before do
       visit tasks_path
-      expect(page).to have_content task.name
+    end
+    
+    it '一覧で表示される' do
+      expect(page).to have_content task_order0.name
+      expect(page).to have_content task_order0.created_at
+    end
+
+    it '作成日の降順で並ぶ' do
+      page.all(".task").each_with_index do | task, idx | 
+        display_text = task.find_by_id('task_created_at').text
+        expect(display_text).to eq eval("task_order#{idx}").created_at.to_s
+      end
     end
     
   end


### PR DESCRIPTION
[**ステップ12**](https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9712-%E3%82%BF%E3%82%B9%E3%82%AF%E4%B8%80%E8%A6%A7%E3%82%92%E4%BD%9C%E6%88%90%E6%97%A5%E6%99%82%E3%81%AE%E9%A0%86%E7%95%AA%E3%81%A7%E4%B8%A6%E3%81%B3%E6%9B%BF%E3%81%88%E3%82%88%E3%81%86)
- やったこと
タスク一覧に作成日を表示
タスク一覧の作成日表示のテスト追加
タスク一覧の取得を作成日の降順に変更
タスク一覧の表示順序のテスト追加

- 確認したこと
タスク一覧が作成日の降順で並ぶか画面で確認
テスト実行

- 確認してほしいこと
sortをかける場合の取得方法が正しいかどうか
並び順を確認するテストが正しいかどうか