### PR TITLE
ステップ15: ステータスを追加して、検索できるようにしよう

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,3 +61,5 @@ gem 'pg'
 gem 'annotate'
 
 gem 'rails-i18n'
+
+gem 'enum_help'

--- a/Gemfile
+++ b/Gemfile
@@ -63,3 +63,5 @@ gem 'annotate'
 gem 'rails-i18n'
 
 gem 'enum_help'
+
+gem 'ransack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,8 @@ GEM
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     pg (1.2.3)
+    polyamorous (2.3.2)
+      activerecord (>= 5.2.1)
     public_suffix (4.0.6)
     puma (4.3.6)
       nio4r (~> 2.0)
@@ -151,6 +153,11 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.20.3, < 2.0)
     rake (13.0.1)
+    ransack (2.3.2)
+      activerecord (>= 5.2.1)
+      activesupport (>= 5.2.1)
+      i18n
+      polyamorous (= 2.3.2)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -243,6 +250,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.3)
   rails-i18n
+  ransack
   rspec-rails
   rspec_junit_formatter
   sass-rails (>= 6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,8 @@ GEM
     concurrent-ruby (1.1.7)
     crass (1.0.6)
     diff-lcs (1.4.4)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.9.0)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
@@ -233,6 +235,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
+  enum_help
   factory_bot_rails
   jbuilder (~> 2.7)
   listen (~> 3.2)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,7 +3,7 @@ class TasksController < ApplicationController
 
   def index
     @search = Task.ransack(params[:q])
-    @tasks = @search.result
+    @tasks = @search.result.recent
   end
   
   def show

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -52,7 +52,7 @@ class TasksController < ApplicationController
     end
 
     def task_params
-      params.require(:task).permit(:name, :description, :expired_at)
+      params.require(:task).permit(:name, :description, :status, :expired_at)
     end
 
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,8 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:edit, :show, :update, :destroy]
 
   def index
-    @tasks = Task.sorted_by_expired_at(params[:order]).recent
+    @search = Task.ransack(params[:q])
+    @tasks = @search.result
   end
   
   def show
@@ -52,7 +53,7 @@ class TasksController < ApplicationController
     end
 
     def task_params
-      params.require(:task).permit(:name, :description, :status, :expired_at)
+      params.require(:task).permit(:name, :description, :status, :expired_at, :status_eq)
     end
 
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -7,9 +7,13 @@
 #  expired_at  :datetime
 #  name        :string
 #  priority    :integer
-#  status      :integer          default(0)
+#  status      :integer          default("ready")
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_tasks_on_status_and_name  (status,name)
 #
 class Task < ApplicationRecord
     validates :name, presence: true, length: { maximum: 30 }
@@ -18,7 +22,6 @@ class Task < ApplicationRecord
     
     # 一時的にコメントアウト
     # validates :priority
-    # validates :status, presence: true
 
     enum status: { 'ready': 0, 'started': 1, 'done': 2 }
 
@@ -26,12 +29,4 @@ class Task < ApplicationRecord
         errors.add(:expired_at, 'は現在日以降の日付を入力してください') if expired_at.nil? || Date.parse(expired_at.to_s) < Date.today
     end
 
-    scope :sorted_by_expired_at, -> (order) {
-        case order
-        when 'asc' then order(expired_at: :asc)
-        when 'desc' then order(expired_at: :desc)
-        end
-    }
-
-    scope :recent, -> { order(created_at: :desc) }
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -7,7 +7,7 @@
 #  expired_at  :datetime
 #  name        :string
 #  priority    :integer
-#  status      :integer
+#  status      :integer          default(0)
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #
@@ -19,6 +19,8 @@ class Task < ApplicationRecord
     # 一時的にコメントアウト
     # validates :priority
     # validates :status, presence: true
+
+    enum status: { 'ready': 0, 'started': 1, 'done': 2 }
 
     def expired_at_valid?        
         errors.add(:expired_at, 'は現在日以降の日付を入力してください') if expired_at.nil? || Date.parse(expired_at.to_s) < Date.today

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -13,7 +13,7 @@
 #
 # Indexes
 #
-#  index_tasks_on_status_and_name  (status,name)
+#  index_tasks_on_status  (status)
 #
 class Task < ApplicationRecord
     validates :name, presence: true, length: { maximum: 30 }

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -29,4 +29,6 @@ class Task < ApplicationRecord
         errors.add(:expired_at, 'は現在日以降の日付を入力してください') if expired_at.nil? || Date.parse(expired_at.to_s) < Date.today
     end
 
+    scope :recent, -> { order(created_at: :desc) }
+    
 end

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -21,6 +21,11 @@
     <div>  
 
     <div class="field">    
+        <%= form.label :status %>
+        <%= form.select :status, Task.statuses.keys.map {|k| [I18n.t("enums.task.status.#{k}"), k] } %>
+    <div>  
+
+    <div class="field">    
         <%= form.label :expired_at %>
         <%= form.datetime_field :expired_at %>
     <div>  

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -2,21 +2,32 @@
 
 <%= link_to "新規作成", new_task_path %>
 
+<div class="task_search_box">
+    <%= search_form_for @search do |form| %>
+
+        <%= form.label :name %>
+        <%= form.search_field :name_cont %>
+
+        <%= form.label :status %>
+        <%= form.select :status_eq, Task.statuses.map {|k, v| [I18n.t("enums.task.status.#{k}"), v] }, {include_blank: true} %>
+
+        <%= form.submit "検索" %>
+    <% end %>
+</div>
+<br />
 <table>
     <tr>
         <th>
-            <%=Task.human_attribute_name("name")%>
+             <%= sort_link(@search, :name) %>
         </th>
         <th>
-            <%=Task.human_attribute_name("expired_at")%>
-            <%= link_to "▲", tasks_path(order: "asc") %>
-            <%= link_to "▼", tasks_path(order: "desc") %>
+            <%= sort_link(@search, :expired_at) %>
         </th>
         <th>
-            <%=Task.human_attribute_name("status")%>
+            <%= sort_link(@search, :status) %>
         </th>
         <th>
-            <%=Task.human_attribute_name("created_at")%>
+            <%= sort_link(@search, :created_at) %>
         </th>
     </tr>
     <% @tasks.each do |task| %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -18,16 +18,16 @@
 <table>
     <tr>
         <th>
-             <%= sort_link(@search, :name) %>
+             <%=Task.human_attribute_name("name")%>
         </th>
         <th>
             <%= sort_link(@search, :expired_at) %>
         </th>
         <th>
-            <%= sort_link(@search, :status) %>
+            <%=Task.human_attribute_name("status")%>
         </th>
         <th>
-            <%= sort_link(@search, :created_at) %>
+            <%=Task.human_attribute_name("created_at")%>
         </th>
     </tr>
     <% @tasks.each do |task| %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -13,6 +13,9 @@
             <%= link_to "▼", tasks_path(order: "desc") %>
         </th>
         <th>
+            <%=Task.human_attribute_name("status")%>
+        </th>
+        <th>
             <%=Task.human_attribute_name("created_at")%>
         </th>
     </tr>
@@ -20,6 +23,7 @@
         <tr class="task_row">
             <td class="task_name"><%= task.name %></td>
             <td class="task_expired_at"><%= task.expired_at %></td>
+            <td class="task_status"><%= task.status_i18n %></td>
             <td class="task_created_at"><%= task.created_at %></td>
             <td><%= link_to "詳細", task_path(task) %></td>
         </tr>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -6,6 +6,9 @@
     <%= @task.description %>
 </div>
 <div>
+    <%= @task.status_i18n %>
+</div>
+<div>
     <span class="task_expired_at">
         <%= @task.expired_at %>
     </span>

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -13,6 +13,7 @@ ja:
           id: ID
           name: タスク名
           description: タスク詳細
+          status: ステータス
           expired_at: 終了期限
   attributes:
     created_at: 作成日

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -1,4 +1,10 @@
 ja:
+  enums:
+      task:
+        status:
+          ready: "未着手"
+          started: "作業中"
+          done: "完了"
   activerecord:
     models:
       task: タスク 

--- a/db/migrate/20201007013012_change_status_of_tasks.rb
+++ b/db/migrate/20201007013012_change_status_of_tasks.rb
@@ -1,0 +1,5 @@
+class ChangeStatusOfTasks < ActiveRecord::Migration[6.0]
+  def change
+    change_column_default :tasks, :status, from: nil, to: 0
+  end
+end

--- a/db/migrate/20201007074509_add_index_to_tasks.rb
+++ b/db/migrate/20201007074509_add_index_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddIndexToTasks < ActiveRecord::Migration[6.0]
+  def change
+    add_index :tasks, [:status, :name]
+  end
+end

--- a/db/migrate/20201008022340_remove_index_of_tasks.rb
+++ b/db/migrate/20201008022340_remove_index_of_tasks.rb
@@ -1,0 +1,5 @@
+class RemoveIndexOfTasks < ActiveRecord::Migration[6.0]
+  def change
+    remove_index :tasks, column: [:status, :name]
+  end
+end

--- a/db/migrate/20201008022846_add_index_of_tasks.rb
+++ b/db/migrate/20201008022846_add_index_of_tasks.rb
@@ -1,0 +1,5 @@
+class AddIndexOfTasks < ActiveRecord::Migration[6.0]
+  def change
+    add_index :tasks, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_02_013735) do
+ActiveRecord::Schema.define(version: 2020_10_07_013012) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 2020_10_02_013735) do
   create_table "tasks", force: :cascade do |t|
     t.string "name"
     t.text "description"
-    t.integer "status"
+    t.integer "status", default: 0
     t.datetime "expired_at"
     t.integer "priority"
     t.datetime "created_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_07_074509) do
+ActiveRecord::Schema.define(version: 2020_10_08_022846) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,7 +23,7 @@ ActiveRecord::Schema.define(version: 2020_10_07_074509) do
     t.integer "priority"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["status", "name"], name: "index_tasks_on_status_and_name"
+    t.index ["status"], name: "index_tasks_on_status"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_07_013012) do
+ActiveRecord::Schema.define(version: 2020_10_07_074509) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 2020_10_07_013012) do
     t.integer "priority"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["status", "name"], name: "index_tasks_on_status_and_name"
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,10 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+if Rails.env.development?
+  # タスク作成のseed
+  10000.times do |n|
+    Task.create!(
+      name: "タスク名#{n + 1}",
+      description: "タスク詳細#{n + 1}", 
+      expired_at: Date.today
+    )
+  end
+end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :task do
     name { 'タスク名' }
     description { 'タスク詳細' }
+    status { 'ready' }
     expired_at { Date.today }
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: tasks
+#
+#  id          :bigint           not null, primary key
+#  description :text
+#  expired_at  :datetime
+#  name        :string
+#  priority    :integer
+#  status      :integer          default(0)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -7,9 +7,13 @@
 #  expired_at  :datetime
 #  name        :string
 #  priority    :integer
-#  status      :integer          default(0)
+#  status      :integer          default("ready")
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_tasks_on_status_and_name  (status,name)
 #
 require 'rails_helper'
 

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -13,7 +13,7 @@
 #
 # Indexes
 #
-#  index_tasks_on_status_and_name  (status,name)
+#  index_tasks_on_status  (status)
 #
 require 'rails_helper'
 

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -131,4 +131,16 @@ RSpec.describe Task, type: :model do
 
     end
   end
+
+  describe 'ステータス' do
+    context '初期状態' do
+
+      let!(:task){ task = Task.new(name: 'name', description: 'description') }
+  
+      it '未着手(ready)である' do
+        expect(task.status).to eq 'ready'
+      end
+    end
+  end
+
 end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -30,22 +30,50 @@ RSpec.describe 'Tasks', type: :system do
       expect(rows[3].find('.task_created_at').text).to eq task.created_at.to_s # 現在日時
     end
 
-    it '終了期限の降順で並ぶ' do
-      click_link '▼'
-      sleep 0.5 # DOMを待つ
-      expect(rows[0].find('.task_expired_at').text).to eq task_add_1year.expired_at.to_s # 現在日時 + 1年
-      expect(rows[1].find('.task_expired_at').text).to eq task_add_1day.expired_at.to_s # 現在日時 + 1日
-      expect(rows[2].find('.task_expired_at').text).to eq task_add_1hour.expired_at.to_s # 現在日時 + 1時間
-      expect(rows[3].find('.task_expired_at').text).to eq task.expired_at.to_s # 現在日時
+    context '終了期限でソートした時' do
+
+      it '昇順で並ぶ' do
+        click_link Task.human_attribute_name("expired_at")
+        sleep 0.5 # DOMを待つ
+        expect(rows[0].find('.task_expired_at').text).to eq task.expired_at.to_s # 現在日時
+        expect(rows[1].find('.task_expired_at').text).to eq task_add_1hour.expired_at.to_s # 現在日時 + 1時間
+        expect(rows[2].find('.task_expired_at').text).to eq task_add_1day.expired_at.to_s # 現在日時 + 1日
+        expect(rows[3].find('.task_expired_at').text).to eq task_add_1year.expired_at.to_s # 現在日時 + 1年
+      end
+
+      it '降順で並ぶ' do
+        
+        2.times do  # 2回クリックして降順にする
+          click_link Task.human_attribute_name("expired_at")
+          sleep 0.5 # DOMを待つ
+        end
+        expect(rows[0].find('.task_expired_at').text).to eq task_add_1year.expired_at.to_s # 現在日時 + 1年
+        expect(rows[1].find('.task_expired_at').text).to eq task_add_1day.expired_at.to_s # 現在日時 + 1日
+        expect(rows[2].find('.task_expired_at').text).to eq task_add_1hour.expired_at.to_s # 現在日時 + 1時間
+        expect(rows[3].find('.task_expired_at').text).to eq task.expired_at.to_s # 現在日時
+      end
+
     end
 
-    it '終了期限の昇順で並ぶ' do
-      click_link '▲'
-      sleep 0.5 # DOMを待つ
-      expect(rows[0].find('.task_expired_at').text).to eq task.expired_at.to_s # 現在日時
-      expect(rows[1].find('.task_expired_at').text).to eq task_add_1hour.expired_at.to_s # 現在日時 + 1時間
-      expect(rows[2].find('.task_expired_at').text).to eq task_add_1day.expired_at.to_s # 現在日時 + 1日
-      expect(rows[3].find('.task_expired_at').text).to eq task_add_1year.expired_at.to_s # 現在日時 + 1年
+
+    context 'タスク名で検索した時' do
+      let(:task_for_search_name){ FactoryBot.create(:task, name: '検索用名称', expired_at: Time.now.next_year + 1.hours) }
+      it '検索した値で表示される' do
+        fill_in 'q_name_cont', with: task_for_search_name.name
+        click_button '検索'
+        expect(rows[0].find('.task_name').text).to eq task_for_search_name.name
+      end
+      
+    end
+
+    context 'ステータスで検索した時' do
+      let!(:task_for_search_status){ FactoryBot.create(:task, status: 'started', expired_at: Time.now.next_year + 1.hours) }
+      it '検索した値で表示される' do
+        value = Task.statuses[task_for_search_status.status].to_s
+        find("option[value='#{value}']").select_option
+        click_button '検索'
+        expect(rows[0].find('.task_status').text).to eq task_for_search_status.status_i18n
+      end
     end
 
   end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe 'Tasks', type: :system do
     
     it '一覧で表示される' do
       expect(page).to have_content task.name
+      expect(page).to have_content task.status_i18n
       expect(page).to have_content task.created_at
       expect(page).to have_content task.expired_at
     end
@@ -57,6 +58,7 @@ RSpec.describe 'Tasks', type: :system do
       visit task_path(task)
       expect(page).to have_content task.name
       expect(page).to have_content task.description
+      expect(page).to have_content task.status_i18n
       expect(page).to have_content task.expired_at
       expect(page).to have_content task.created_at
     end
@@ -81,6 +83,7 @@ RSpec.describe 'Tasks', type: :system do
       it '作成できる' do
         expect(page).to have_content name
         expect(page).to have_content description
+        expect(page).to have_content I18n.t("enums.task.status.ready")
         expect(page).to have_selector '.task_expired_at', text: expired_at.to_s
         expect(page).to have_selector '.task_created_at', text: /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/
         
@@ -120,6 +123,7 @@ RSpec.describe 'Tasks', type: :system do
       it '編集できる' do
         expect(page).to have_content name
         expect(page).to have_content description
+        expect(page).to have_content I18n.t("enums.task.status.ready")
         expect(page).to have_selector '.task_expired_at', text: expired_at.to_s
         expect(page).to have_selector '.task_created_at', text: /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/
       end


### PR DESCRIPTION
[**ステップ15**](https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9715-%E3%82%B9%E3%83%86%E3%83%BC%E3%82%BF%E3%82%B9%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%81%A6%E6%A4%9C%E7%B4%A2%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%82%88%E3%81%86)
- やったこと
enumで日本語化を行うため、enum_helpを追加
検索機能実装のため、ransack追加
タスク一覧、詳細、編集画面にステータスを追加
ransackでソート処理が可能なため、既存の終了期限ソート処理を削除
タスク名、ステータスで検索可能にしたため、index付与
ステータス表示、検索機能のテスト追加

- 確認したこと
タスク名、ステータスで検索できるか確認
終了期限でソート(ransack版)できるか確認
テスト実行

- 確認してほしいこと
enumの使い方が正しいかどうか
検索機能が正しくできているか
検索機能追加に伴うテストが正しくかけているか

