### PR TITLE
ステップ22: ユーザにロールを追加しよう

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,7 +1,8 @@
 class Admin::UsersController < ApplicationController
-  before_action :set_user, only: [:edit, :show, :update, :destroy]
   before_action :auth_session
-
+  before_action :require_admin
+  before_action :set_user, only: [:edit, :show, :update, :destroy]
+  
   def index
     @users = User.all
   end
@@ -55,7 +56,11 @@ class Admin::UsersController < ApplicationController
     end
 
     def user_params
-      params.require(:user).permit(:name, :email, :password)
+      params.require(:user).permit(:name, :email, :password, :password_confirmation, :admin)
+    end
+
+    def require_admin
+      redirect_to root_path unless current_user.admin?
     end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@
 # Table name: users
 #
 #  id              :bigint           not null, primary key
+#  admin           :boolean          default(FALSE), not null
 #  email           :string
 #  name            :string
 #  password_digest :string
@@ -27,8 +28,20 @@ class User < ApplicationRecord
     presence: true,
     length: { minimum: 8 }
 
-  before_save do
-    self.email.downcase! # メールアドレスは小文字で統一 
-  end
+  validate :admin_validation, if: :will_save_change_to_admin?
+
+  before_save :downcase_email
+
+  private
+
+    def admin_validation
+      return if self.admin?
+      admin_count = User.where(admin: true).count
+      errors.add(:admin, 'は最低1ユーザー保持する必要があります') if admin_count == 1
+    end
+
+    def downcase_email
+      self.email.downcase! 
+    end
 
 end

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -19,9 +19,18 @@
     <div class="field">
       <%= form.email_field :email, class: "form-control", placeholder: User.human_attribute_name("email") %>
     </div>
-    
+
     <div class="field">
       <%= form.password_field :password, class: "form-control", placeholder: User.human_attribute_name("password") %>
+    </div>
+
+    <div class="field">
+      <%= form.password_field :password_confirmation, class: "form-control", placeholder: User.human_attribute_name("password_confirmation") %>
+    </div>
+
+    <div class="field">
+      <%= form.label :admin %>
+      <%= form.check_box :admin, class: "form-check-label" %>
     </div>
 
     <%= form.submit "保存", class: "btn btn-success create_user_btn"%>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -14,6 +14,9 @@
                 タスク数
             </th>
             <th>
+                <%=User.human_attribute_name("admin")%>
+            </th>
+            <th>
             </th>
         </tr>
         <% @users.each do |user| %>
@@ -21,6 +24,7 @@
             <td class="user_name"><%= user.name %></td>
             <td class="user_email"><%= user.email %></td>
             <td><%= link_to user.tasks.count, admin_user_tasks_path(user) %></td>
+            <td class="user_admin"><%= user.admin? ? '有り': '無し' %></td>
             <td><%= link_to "詳細", admin_user_path(user) %></td>
         </tr>
         <% end %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -7,11 +7,17 @@
                 </span>
             </h4>
             <p class="card-text">
+                <%=User.human_attribute_name("email")%> :
                 <span class="user_email">
                     <%= @user.email %>
                 </span>
             </p>
-            
+            <p class="card-text">
+                <%=User.human_attribute_name("admin")%> :
+                <span class="user_email">
+                    <%= @user.admin? ? '有り': '無し' %>
+                </span>
+            </p>
             <%= link_to '編集', edit_admin_user_path(@user) %>
             <%= link_to "削除", admin_user_path(@user), method: :delete, data: { confirm: "ユーザーを削除してもよろしいですか？" } %>
             <%= link_to '一覧に戻る', admin_users_path %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,9 +6,11 @@
       <li class="nav-item">
         <%= link_to "タスク作成", new_task_path, class: "nav-link text-white" %>
       </li>
+      <% if current_user.admin? %>
       <li class="nav-item">
         <%= link_to "ユーザー管理", admin_users_path, class: "nav-link text-white" %>
       </li>
+      <% end %>
       <li class="nav-item">
         <%= link_to "ログアウト", logout_path, method: :delete, class: "nav-link text-white" %>
       </li>

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -26,6 +26,8 @@ ja:
           name: ユーザー名
           email: メールアドレス
           password: パスワード
+          password_confirmation: パスワード(確認用)
+          admin: 管理者権限
   attributes:
     created_at: 作成日
     updated_at: 更新日

--- a/db/migrate/20201013014038_add_admin_to_users.rb
+++ b/db/migrate/20201013014038_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :admin, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_09_052930) do
+ActiveRecord::Schema.define(version: 2020_10_13_014038) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 2020_10_09_052930) do
     t.string "password_digest"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "admin", default: false, null: false
   end
 
   add_foreign_key "tasks", "users"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,11 +1,13 @@
 if Rails.env.development?
+
+  # 一般ユーザー作成
   user = User.create!(
     name: "ダミーユーザー",
     email: "dummy@example.com",
     password: "12345678"
   )
-  # タスク作成のseed
-  Task.delete_all
+
+  # 一般ユーザータスク作成
   100.times do |n|
     Task.create!(
       name: "タスク名#{n + 1}",
@@ -14,4 +16,13 @@ if Rails.env.development?
       user_id: user.id
     )
   end
+
+  # 管理者ユーザー作成
+  User.create!(
+    name: "管理者",
+    email: "admin@example.com",
+    password: "12345678"
+    admin: true
+  )
+
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,6 +3,7 @@
 # Table name: users
 #
 #  id              :bigint           not null, primary key
+#  admin           :boolean          default(FALSE), not null
 #  email           :string
 #  name            :string
 #  password_digest :string
@@ -14,5 +15,7 @@ FactoryBot.define do
     sequence(:name) { |n| "dummy_name#{n}"}
     sequence(:email) { |n| "dummy#{n}@example.com"}
     password { "12345678" }
+    password_confirmation { "12345678" }
+    admin { true }
   end
 end

--- a/spec/system/admin/users_spec.rb
+++ b/spec/system/admin/users_spec.rb
@@ -7,16 +7,37 @@ RSpec.describe "Users", type: :system do
 
   describe "一覧" do
 
-    before do
-      login(user)
-      visit admin_users_path
+    context "管理者ユーザーの場合" do
+
+      before do
+        login(user)
+        visit admin_users_path
+      end
+
+      it "ユーザー一覧が表示される" do
+        expect(page).to have_content user.name
+        expect(page).to have_content user.email
+        expect(page).to have_content user.tasks.count
+        expect(page).to have_content user.admin? ? "有り" : "無し"
+      end
+
     end
 
-    it "ユーザー一覧が表示される" do
-      expect(page).to have_content user.name
-      expect(page).to have_content user.email
-      expect(page).to have_content user.tasks.count
+    context "管理者権限の無いユーザーの場合" do
+
+      let(:non_admin_user) { create(:user, admin: false) }
+
+      before do
+        login(non_admin_user)
+        visit admin_users_path
+      end
+
+      it "ルートページが表示される" do
+        expect(page).to have_current_path root_path
+      end
+
     end
+    
 
   end
 
@@ -30,6 +51,7 @@ RSpec.describe "Users", type: :system do
     it "ユーザー詳細が表示される" do
       expect(page).to have_content user.name
       expect(page).to have_content user.email
+      expect(page).to have_content user.admin? ? "有り" : "無し"
     end
     
   end
@@ -41,7 +63,9 @@ RSpec.describe "Users", type: :system do
       visit new_admin_user_path
       fill_in "user_name",	with: name
       fill_in "user_email",	with: email
-      fill_in "user_password",	with: "12345678"
+      fill_in "user_password",	with: password
+      fill_in "user_password_confirmation",	with: password
+      uncheck "user_admin"
       click_button "保存"
     end
 
@@ -49,10 +73,12 @@ RSpec.describe "Users", type: :system do
 
       let(:name) { "ユーザー名" }
       let(:email) { "test@example.com" }
+      let(:password) { "12345678" }
 
       it "ユーザーを作成できる" do
         expect(page).to have_content name
         expect(page).to have_content email
+        expect(page).to have_content "無し"
       end
 
     end
@@ -66,36 +92,115 @@ RSpec.describe "Users", type: :system do
       visit edit_admin_user_path(user)
       fill_in "user_name",	with: name
       fill_in "user_email",	with: email
-      fill_in "user_password",	with: "12345678"
-      click_button "保存"
+      fill_in "user_password",	with: password
+      fill_in "user_password_confirmation",	with: password
     end
 
     context "編集した時" do
 
       let(:name) { "ユーザー名(変更語)" }
       let(:email) { "test_modified@example.com" }
+      let(:password) { "12345678" }
 
       it "ユーザーを編集できる" do
+        click_button "保存"
         expect(page).to have_content name
         expect(page).to have_content email
+        expect(page).to have_content "有り"
       end
 
     end
+
+    context "管理者ユーザー2人以上の状態で管理者権限を外した時" do
+
+      let!(:admin_user) { create(:user) }
+
+      let(:name) { "ユーザー名(変更語)" }
+      let(:email) { "test_modified@example.com" }
+      let(:password) { "12345678" }
+
+      before do
+        uncheck "user_admin"
+        click_button "保存"
+      end
+
+      it "ルートページが表示される" do
+        expect(page).to have_current_path root_path
+      end
+
+    end
+
+    context "管理者ユーザー1人の状態で管理者権限を外した時" do
+
+      let(:name) { "ユーザー名(変更語)" }
+      let(:email) { "test_modified@example.com" }
+      let(:password) { "12345678" }
+
+      before do
+        uncheck "user_admin"
+        click_button "保存"
+      end
+
+      it "エラーになる" do
+        expect(page).to have_content "は最低1ユーザー保持する必要があります"
+      end
       
+    end
+    
   end
 
   describe "削除" do
 
-    before do
-      login(user)
-      visit admin_user_path(user)
-      page.accept_confirm do
-        click_on "削除"
+    context "管理者ユーザー以外を削除した場合" do
+
+      let!(:non_admin_user) { create(:user, admin: false) }
+
+      before do
+        login(user)
+        visit admin_user_path(non_admin_user)
+        page.accept_confirm do
+          click_on "削除"
+        end
       end
+  
+      it "ユーザーを削除できる" do
+        expect(page).to have_content "ユーザーを削除しました"
+      end
+      
     end
 
-    it "ユーザーを削除できる" do
-      expect(page).to have_content "ユーザーを削除しました"
+    context "管理者ユーザー2人以上の状態で管理者を削除した場合" do
+
+      let!(:admin_user) { create(:user) }
+
+      before do
+        login(user)
+        visit admin_user_path(admin_user)
+        page.accept_confirm do
+          click_on "削除"
+        end
+      end
+  
+      it "ユーザーを削除できる" do
+        expect(page).to have_content "ユーザーを削除しました"
+      end
+      
+    end
+
+    context "管理者ユーザー1人の状態で管理者を削除した場合" do
+
+      before do
+        login(user)
+        visit admin_user_path(user)
+        page.accept_confirm do
+          click_on "削除"
+        end
+      end
+  
+      it "エラーになる" do
+        expect(page).to have_content "は最低1ユーザー保持する必要があります"
+      end
+
     end
 
   end


### PR DESCRIPTION
[**ステップ22**](https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9722-%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AB%E3%83%AD%E3%83%BC%E3%83%AB%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%82%88%E3%81%86)
- やったこと
Userモデルにadminカラム(管理者権限)を追加
管理者権限がtrueの場合のみユーザー管理機能に遷移可能にした
管理者権限を持つユーザーが1人しかいない場合は管理者を削除できないようにした
管理者権限追加に伴うテスト追加

- 確認したこと
管理者権限が無い場合はユーザー管理画面に遷移できないこと
管理者権限を持つユーザーが1人しかいない場合に削除できないこと
テスト実行

- 確認してほしいこと
最後の1ユーザーの削除の際のバリデーションが正しくできているか
権限管理が正しくできているか
追加のテストが正しく書けているか